### PR TITLE
FACILITY-15955 updated unserved file types

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,11 +40,21 @@ http {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
             proxy_pass https://s3-us-west-2.amazonaws.com/img-recoveryfirst-org/wp-content/uploads/;
         }
-        
+
         # Media: images, icons, video, audio, HTC, 4 hours
-        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|webp|htc|woff|woff2)$ {
+        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|svg|svgz|mp4|ogg|ogv|webm|webp|htc|woff|woff2)$ {
             add_header Cache-Control "public, max-age=14400, must-revalidate";
             root /var/app/current;
+        }
+
+        # slow attacks by quickly returning unserved file types
+        location ~* \.(bak|zip|tar|gz|sql|php|env|aspx)$|/\. {
+             return 403;
+        }
+
+        # slow attacks by quickly returning ads.txt
+        location ~ ^/(ads\.txt)$ {
+            return 403;
         }
 
         # CSS and Javascript, 4 hours


### PR DESCRIPTION
https://recoverybrands.atlassian.net/browse/FACILITY-15955

Description:
FACILITY-15955 updated unserved file types

Example Links:
https://staging.recoveryfirst.org/test.bak
https://staging.recoveryfirst.org/test.zip
https://staging.recoveryfirst.org/test.tar
https://staging.recoveryfirst.org/test.gz
https://staging.recoveryfirst.org/test.sql
https://staging.recoveryfirst.org/test.php
https://staging.recoveryfirst.org/test.env
https://staging.recoveryfirst.org/test.aspx
https://staging.recoveryfirst.org/test.env.aspx
https://staging.recoveryfirst.org/ads.txt

Note: Only ads.txt should be blocked. We need robots.txt to load.

https://staging.recoveryfirst.org/robots.txt

Screenshot:
![image](https://github.com/American-Addiction-Centers/recoveryfirst-org-nginx/assets/86256771/33b6ead4-e9c5-4c6f-92f9-e9f8d00ca132)
